### PR TITLE
增加2019版本的条件编译

### DIFF
--- a/Assets/LuaFramework/Editor/CustomSettings.cs
+++ b/Assets/LuaFramework/Editor/CustomSettings.cs
@@ -97,24 +97,24 @@ public static class CustomSettings
 #endif
       
         _GT(typeof(Behaviour)),
-        _GT(typeof(MonoBehaviour)),        
+        _GT(typeof(MonoBehaviour)),
         _GT(typeof(GameObject)),
         _GT(typeof(TrackedReference)),
         _GT(typeof(Application)),
         _GT(typeof(Physics)),
         _GT(typeof(Collider)),
-        _GT(typeof(Time)),        
+        _GT(typeof(Time)),
         _GT(typeof(Texture)),
         _GT(typeof(Texture2D)),
-        _GT(typeof(Shader)),        
+        _GT(typeof(Shader)),
         _GT(typeof(Renderer)),
         _GT(typeof(WWW)),
-        _GT(typeof(Screen)),        
+        _GT(typeof(Screen)),
         _GT(typeof(CameraClearFlags)),
-        _GT(typeof(AudioClip)),        
+        _GT(typeof(AudioClip)),
         _GT(typeof(AssetBundle)),
         _GT(typeof(ParticleSystem)),
-        _GT(typeof(AsyncOperation)).SetBaseType(typeof(System.Object)),        
+        _GT(typeof(AsyncOperation)).SetBaseType(typeof(System.Object)),
         _GT(typeof(LightType)),
         _GT(typeof(SleepTimeout)),
 #if UNITY_5_3_OR_NEWER && !UNITY_5_6_OR_NEWER
@@ -124,8 +124,8 @@ public static class CustomSettings
         _GT(typeof(Input)),
         _GT(typeof(KeyCode)),
         _GT(typeof(SkinnedMeshRenderer)),
-        _GT(typeof(Space)),      
-       
+        _GT(typeof(Space)),
+
 
         _GT(typeof(MeshRenderer)),
 #if !UNITY_5_4_OR_NEWER
@@ -136,21 +136,25 @@ public static class CustomSettings
 
         _GT(typeof(BoxCollider)),
         _GT(typeof(MeshCollider)),
-        _GT(typeof(SphereCollider)),        
+        _GT(typeof(SphereCollider)),
         _GT(typeof(CharacterController)),
         _GT(typeof(CapsuleCollider)),
-        
-        _GT(typeof(Animation)),        
-        _GT(typeof(AnimationClip)).SetBaseType(typeof(UnityEngine.Object)),        
+
+        _GT(typeof(Animation)),
+        _GT(typeof(AnimationClip)).SetBaseType(typeof(UnityEngine.Object)),
         _GT(typeof(AnimationState)),
         _GT(typeof(AnimationBlendMode)),
-        _GT(typeof(QueueMode)),  
+        _GT(typeof(QueueMode)),
         _GT(typeof(PlayMode)),
         _GT(typeof(WrapMode)),
 
         _GT(typeof(QualitySettings)),
         _GT(typeof(RenderSettings)),
+#if UNITY_2019
         _GT(typeof(SkinWeights)),
+#else
+        _GT(typeof(BlendWeights)),
+#endif
         _GT(typeof(RenderTexture)), 
 		_GT(typeof(Resources)),      
 		_GT(typeof(LuaProfiler)),
@@ -193,7 +197,11 @@ public static class CustomSettings
         typeof(Animation),
         typeof(AnimationClip),
         typeof(AnimationState),
-        typeof(SkinWeights),
+#if UNITY_2019
+        _GT(typeof(SkinWeights)),
+#else
+        _GT(typeof(BlendWeights)),
+#endif
         typeof(RenderTexture),
         typeof(Rigidbody),
     };

--- a/Assets/LuaFramework/Editor/CustomSettings.cs
+++ b/Assets/LuaFramework/Editor/CustomSettings.cs
@@ -198,9 +198,9 @@ public static class CustomSettings
         typeof(AnimationClip),
         typeof(AnimationState),
 #if UNITY_2019
-        _GT(typeof(SkinWeights)),
+        typeof(SkinWeights),
 #else
-        _GT(typeof(BlendWeights)),
+        typeof(BlendWeights),
 #endif
         typeof(RenderTexture),
         typeof(Rigidbody),


### PR DESCRIPTION
Unity2019弃用BlendWeights改为SkinWeights